### PR TITLE
Update brew install command

### DIFF
--- a/src/pages/download.js
+++ b/src/pages/download.js
@@ -190,7 +190,7 @@ class DownloadPage extends Component {
 
                         <h4>Install with Homebrew</h4>
                         <pre className={"command"}>
-                            $ brew cask install ferdi
+                            $ brew install --cask ferdi
                         </pre>
 
                         <h4>Install AUR package</h4>


### PR DESCRIPTION
The command `brew cask install ...` is deprecated and in most newer versions also disabled.
I've updated the listed command to reflect the change and use the new format.