### PR TITLE
Updates download links to the latest v5.6.2.

### DIFF
--- a/src/pages/download.js
+++ b/src/pages/download.js
@@ -14,7 +14,7 @@ class DownloadPage extends Component {
 
   componentDidMount() {
     // const version = await this.getLatestRelease();
-    const version = '5.6.0';
+    const version = '5.6.2';
 
     this.setState({
       release: version,


### PR DESCRIPTION
Changes the download links from version 5.6.0 to version 5.6.2, for the users to use the latest version, which has the dark theme fixed for Facebook Messenger.